### PR TITLE
Replaced size() with length

### DIFF
--- a/jquery.formtowizard.js
+++ b/jquery.formtowizard.js
@@ -31,7 +31,7 @@
 
         var element = this
             , steps = $( element ).find( "fieldset" )
-            , count = steps.size()
+            , count = steps.length
             , submmitButtonName = "#" + options.submitButton
             , commands = null;
 


### PR DESCRIPTION
size() was deprecated in jQuery 1.8 and
removed in 3.0