### PR TITLE
Fix tabindex issue by swapping createPrevButton/createNextButton.

### DIFF
--- a/jquery.formtowizard.js
+++ b/jquery.formtowizard.js
@@ -76,8 +76,8 @@
                 }
                 else {
                     $("#step" + i).hide();
-                    createPrevButton(i);
                     createNextButton(i);
+                    createPrevButton(i);
                 }
             });
 


### PR DESCRIPTION
Swapped createPrevButton/createNextButton order to fix an issue with the buttons [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex). The original order would create a button that tabs to Previous before Next.

I'm not too familiar with Fiddle, but I can fiddle (heh) with it to provide an example if you'd like.